### PR TITLE
Kulvir/create user endpoint

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -84,7 +84,12 @@ func (db *Database) CreateEmptyFile(fileName string, userID string) (int, int, e
 
 // CreateUser creates a user with the given username
 // returns the new user's ID
+// TODO @nikita: get rid of the int being returned here?
 func (db *Database) CreateUser(username string) (int, error) {
+	if username == "" {
+		return -1, errors.New("empty username")
+	}
+
 	conn, err := sqlite3.Open(db.Path)
 	defer conn.Close()
 	if err != nil {

--- a/database/interface.go
+++ b/database/interface.go
@@ -6,6 +6,9 @@ import (
 
 // Interface contains all the functions that interact with the database.
 type Interface interface {
+	// Creates a new user with the given username and adds it to the user database.
+	CreateUser(userName string) (int, error)
+
 	// Creates a new file, stores it in the database, and returns the id for it as well as the latest revision.
 	CreateEmptyFile(fileName string, userID string) (int, int, error)
 

--- a/database/mockDB.go
+++ b/database/mockDB.go
@@ -20,6 +20,15 @@ type MockDB struct {
 	Changes []obj.Change
 }
 
+// CreateUser returns an error if the given username string is empty, otherwise returns nil.
+// TODO: Once Nikita removes the int from his method, remove it here too.
+func (m *MockDB) CreateUser(username string) (int, error) {
+	if username == "" {
+		return -1, errors.New("cannot create a user with an empty username")
+	}
+	return 1, nil
+}
+
 // CreateEmptyFile increments the FileCounter and returns it to mock creating a file.
 // Returns an error if we have already created the maximum number of files (arbitrarily imposed limit to test error response)
 func (m *MockDB) CreateEmptyFile(fileName string, userName string) (int, int, error) {

--- a/database/mockDB_test.go
+++ b/database/mockDB_test.go
@@ -6,6 +6,24 @@ import (
 	obj "github.com/Dabblr/Concurrent-Document-Editor/objects"
 )
 
+// Tests that CreateUser returns an error when the username passed to it is an empty string.
+func TestMockCreateUserReturnsErrorWhenEmptyUsername(t *testing.T) {
+	var m MockDB
+	_, err := m.CreateUser("")
+	if err == nil {
+		t.Errorf("Expected CreateUser to return an error when the username is empty but got nil.")
+	}
+}
+
+// Tests that Create User does not return an error when the username passed is a non-empty string.
+func TestMockCreateUserReturnsNilWhenNonEmptyUsername(t *testing.T) {
+	var m MockDB
+	_, err := m.CreateUser("user1")
+	if err != nil {
+		t.Errorf("Expected CreateUser to return nil but got the following error: %v.", err)
+	}
+}
+
 // Tests that CreateEmptyFile returns the value of FileCounter incremented by 1.
 func TestMockCreateEmptyFileReturnsIncrementedCounter(t *testing.T) {
 	var m MockDB

--- a/objects/file.go
+++ b/objects/file.go
@@ -5,7 +5,7 @@ import "fmt"
 // File contains information about each file.
 type File struct {
 	// The username of the user updating the file.
-	User string `json:"user,omitempty"`
+	User string `json:"user"`
 	// The ID of the file (generated on server).
 	ID int `json:"id"`
 	// The name of the file.

--- a/server/server_tests.postman_collection.json
+++ b/server/server_tests.postman_collection.json
@@ -7,6 +7,244 @@
 	},
 	"item": [
 		{
+			"name": "create_user_tests",
+			"item": [
+				{
+					"name": "TestUserCreationNoBody",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6835e72b-7a61-4a09-80d7-1ef8d420a0db",
+								"exec": [
+									"pm.test(\"Response status is 400 Bad Request\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Response has no body\", function() {",
+									"   pm.response.to.not.be.withBody; ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:8080/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"users"
+							]
+						},
+						"description": "Verifies that the response status code is 400 Bad Request when a POST request to the `/users` endpoint has no body."
+					},
+					"response": []
+				},
+				{
+					"name": "TestUserCreationInvalidJSON",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f08d1db-2519-459f-9b8b-c5f0d0aacf55",
+								"exec": [
+									"pm.test(\"Response status is 400 Bad Request\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Response has no body\", function() {",
+									"   pm.response.to.not.be.withBody; ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\t\n\t\"user\":user1\n}"
+						},
+						"url": {
+							"raw": "http://localhost:8080/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"users"
+							]
+						},
+						"description": "Verifies that the response status code is 400 Bad Request when a POST request to the `/users` endpoint contains invalid/poorly formed JSON."
+					},
+					"response": []
+				},
+				{
+					"name": "TestUserCreationMissingUser",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7c63ab5e-2760-4dce-8d64-d87cab7ddfc7",
+								"exec": [
+									"pm.test(\"Response status is 400 Bad Request\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Response has no body\", function() {",
+									"   pm.response.to.not.be.withBody; ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\t\n\t\"name\": \"file1.txt\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:8080/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"users"
+							]
+						},
+						"description": "Verifies that the response status code is 400 Bad Request when a POST request to the `/users` endpoint is missing a `user` field in the JSON body."
+					},
+					"response": []
+				},
+				{
+					"name": "TestUserCreationEmptyUsername",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fdbc6014-5f31-4892-8490-3542890602fa",
+								"exec": [
+									"pm.test(\"Response status is 400 Bad Request\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Response has no body\", function() {",
+									"   pm.response.to.not.be.withBody; ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"user\":\"\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:8080/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"users"
+							]
+						},
+						"description": "Verifies that the response status code is 400 Bad Request when a POST request to the `/users` endpoint has an empty string `user` field in the JSON body."
+					},
+					"response": []
+				},
+				{
+					"name": "TestUserCreationSuccess",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "60de0d19-d055-45a6-97ba-6b946152e5e3",
+								"exec": [
+									"// Tests that the response status is 201 Created.",
+									"pm.test(\"Response status is 201 Created\", function() {",
+									"   pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response has no body\", function() {",
+									"   pm.response.to.not.be.withBody; ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\t\n\t\"user\":\"user1\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:8080/users",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"users"
+							]
+						},
+						"description": "Verifies that the response has a 201 status code after a successful POST request to the `/users` endpoint."
+					},
+					"response": []
+				}
+			],
+			"description": "Contains tests for creating a user at the `/users` endpoint."
+		},
+		{
 			"name": "create_file_tests",
 			"item": [
 				{
@@ -1069,19 +1307,19 @@
 	],
 	"variable": [
 		{
-			"id": "7a626478-f1cb-46f7-9d0b-af6bbe7d3d08",
+			"id": "a35316c5-d94e-4491-93ef-915f9938f3ce",
 			"value": "",
 			"type": "string",
 			"disabled": true
 		},
 		{
-			"id": "62f2e5b1-755e-4bd2-8b73-1f401be35fc1",
+			"id": "6d3217f0-286c-48b8-bd2f-8552ce22ac37",
 			"value": "",
 			"type": "string",
 			"disabled": true
 		},
 		{
-			"id": "08d82fa7-072f-46ca-8afd-bd5ae57ad17b",
+			"id": "ddcce65e-0813-4c40-a340-27e13014a869",
 			"value": "",
 			"type": "string",
 			"disabled": true


### PR DESCRIPTION
In this PR, I created a server endpoint for creating users, and added a function to create a user to the database interface and to the mock database. 
I also added tests to the Postman collection to test the user creation endpoint. With these changes, all Postman tests pass on the real and mock database since we are now actually populating the users table.